### PR TITLE
Change background of release details blocks

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -316,19 +316,19 @@ span.special {
 }
 
 #release-notes details {
-margin-bottom: 1em;
-background: #1e1e1e;
-padding: 1em;
-border-radius: 8px;
-border: 1px solid #333;
+  margin-bottom: 1em;
+  background: hsl(0, 0%, 95%);
+  padding: 1em;
+  border-radius: 8px;
+  border: 1px solid #333;
 }
 
 #release-notes summary {
-cursor: pointer;
-font-size: 1.1em;
+  cursor: pointer;
+  font-size: 1.1em;
 }
 
 #release-notes ul {
-margin-top: 0.5em;
-padding-left: 1.5em;
+  margin-top: 0.5em;
+  padding-left: 1.5em;
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -3,6 +3,7 @@
   --text: 245,245,245;
   --accent: #81cdc3;
   --card-bg: #1e194d;
+  --release-notes-bg: #1e1e1e;
   --gradient: linear-gradient(
       147deg,
       #382d7a 0%,
@@ -21,6 +22,7 @@
     --text: 7, 5, 16;
     --accent: #36337f;
     --card-bg: #1e194d;
+    --release-notes-bg: hsl(0, 0%, 95%);
   }
 }
 
@@ -317,7 +319,7 @@ span.special {
 
 #release-notes details {
   margin-bottom: 1em;
-  background: hsl(0, 0%, 95%);
+  background: var(--release-notes-bg);
   padding: 1em;
   border-radius: 8px;
   border: 1px solid #333;


### PR DESCRIPTION
In light mode, the text here was black-on-nearly-black and totally unreadable on every browser I tried.

## Before
<img width="978" height="505" alt="image" src="https://github.com/user-attachments/assets/90fae454-8e1d-4181-a621-2d5e9789af2e" />

## After
<img width="981" height="469" alt="image" src="https://github.com/user-attachments/assets/3bcb55bf-1610-4c6c-947c-5d53ba24791d" />
