### PR TITLE
Enhance Known Issues link in changelog.html

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -3,10 +3,11 @@ layout: default
 title: Release Notes - Foundryborne
 ---
 <section id="release-notes">
+    
     <h2>Release Notes</h2>
     <!-- Keep Known Issues on top -->
     <p>
-        <a href="https://github.com/Foundryborne/daggerheart/wiki/Known-Issues-and-Workarounds">Known Issues</a>
+        <a href="https://github.com/Foundryborne/daggerheart/wiki/Known-Issues-and-Workarounds">Known Issues<sub>[Wiki]</sub></a>
     </p>
     <div class="release-log">
         <details id="v1.5.0">


### PR DESCRIPTION
Updated the Known Issues link to include a subscript to denote that it is going to 'Wiki' and not on website.